### PR TITLE
Add support for Web Audio API

### DIFF
--- a/lib/audio.js
+++ b/lib/audio.js
@@ -36,6 +36,15 @@ var audio = {};
         dataToFile(waveTag + btoa(constructWave(arrayToData(arr))))
     };
     
+    this.makeAudioBuffer = function(ctx, data) {
+        var buffer = ctx.createBuffer(1, data.length, SampleRate);
+        var array = buffer.getChannelData(0);
+        for (var i = 0; i < data.length; ++i) {
+            array[i] = data[i];
+        }
+        return buffer;
+    };
+
     //////////////////////
     // General stuff   ///
     //////////////////////

--- a/lib/jsfxlib.js
+++ b/lib/jsfxlib.js
@@ -30,6 +30,46 @@ var jsfxlib = {};
         return wave;
     }
 
+    // takes object with param arrays
+    //
+    //     var audiolib = {
+    //       someSound : ["sine", 1, 2, 4, 1...
+    //     }
+    //
+    // returns object with AudioBuffers you can use
+    // with the Web Audio API
+    //
+    //     var sounds = jsfxlib.createAudioBuffers(ctx, audiolib);
+    //     var ctx = new AudioContext();
+    //     var src = ctx.createBufferSource();
+    //     src.buffer = sounds.someSound;
+    //     src.connect(ctx.destination);
+    //     src.start();
+    this.createAudioBuffers = function(ctx, lib) {
+        var sounds = {};
+        for (var e in lib) {
+            var data = lib[e];
+            sounds[e] = this.createAudioBuffer(ctx, data);
+        }
+        return sounds;
+    }
+
+    // Create a single AudioBuffer
+    //
+    //     var buffer = jsfxlib.createAudioBuffer(ctx, ["sine", 1,2,3, etc.]);
+    //     var ctx = new AudioContext();
+    //     var src = ctx.createBufferSource();
+    //     src.buffer = buffer;
+    //     src.connect(ctx.destination);
+    //     src.start();
+    this.createAudioBuffer = function(ctx, lib) {
+        var params = this.arrayToParams(lib),
+            data = jsfx.generate(params),
+            buffer = audio.makeAudioBuffer(ctx, data);
+
+        return buffer;
+    }
+
     this.paramsToArray = function(params){
         var pararr = [];
         var len = jsfx.Parameters.length;


### PR DESCRIPTION
I'm not sure you want this or not given that it's pretty simple.

I did test it though by editing jsfxgui with the following patch

```
diff --git a/lib/jsfxgui.js b/lib/jsfxgui.js
index d32d798..966b081 100644
--- a/lib/jsfxgui.js
+++ b/lib/jsfxgui.js
@@ -3,6 +3,9 @@ var jsfxgui = {};
     var Parameters = [];
     var logDiv = undefined;

+    var webAudioAPI = window.AudioContext || window.webkitAudioContext || window.mozAudioContext;
+    var ctx = new webAudioAPI();
+
     function log(txt){
         if(logDiv === undefined){
             return;
@@ -384,18 +387,24 @@ var jsfxgui = {};
         var data = jsfx.generate(params);
         if(typeof(wave) !== undefined)
             delete wave;
-        var wave = audio.make(data);
+//        var wave = audio.make(data);
+        var buffer = audio.makeAudioBuffer(ctx, data)
+        var src = ctx.createBufferSource();
+        src.buffer = buffer;
+        src.connect(ctx.destination);
+        src.start();
+
         delete data;        

         var stop = millis();
         log("generate: " + (stop - start) + "ms");          
-        wave.play();
+//        wave.play();

         if(typeof(this.onplay) !== undefined){
             this.onplay();
         }
-        
-        return wave;
+  console.log("pla");
+//        return wave;
     };

     this.reset = function () {
```
