### PR TITLE
jsfx.js can be used as both an IIFE and a node module

### DIFF
--- a/jsfx.js
+++ b/jsfx.js
@@ -1,5 +1,11 @@
-(function(jsfx){
-	'use strict';
+(function(root, factory) {
+  if (typeof module === "object" && typeof module.exports === "object") {
+    module.exports = factory();
+  } else {
+    root.jsfx = factory();
+  }
+}(this, function() {
+      'use strict';
 
 	var chr = String.fromCharCode;
 	var TAU = +Math.PI*2;
@@ -9,6 +15,8 @@
 	var pow = Math.pow;
 	var abs = Math.abs;
 	var EPSILON = 0.000001;
+
+  var jsfx = {};
 
 	jsfx.SampleRate = 0|0;
 	jsfx.Sec = 0|0;
@@ -1120,4 +1128,6 @@
 		}
 		return new Uint8Array(N);
 	}
-})(this.jsfx = {});
+
+  return jsfx;
+}));

--- a/jsfx.js
+++ b/jsfx.js
@@ -1,11 +1,11 @@
 (function(root, factory) {
-  if (typeof module === "object" && typeof module.exports === "object") {
-    module.exports = factory();
-  } else {
-    root.jsfx = factory();
-  }
+	if (typeof module === "object" && typeof module.exports === "object") {
+		module.exports = factory();
+	} else {
+		root.jsfx = factory();
+	}
 }(this, function() {
-      'use strict';
+	'use strict';
 
 	var chr = String.fromCharCode;
 	var TAU = +Math.PI*2;
@@ -1091,11 +1091,11 @@
 	// uniform random
 	function runif(scale, offset){
 		var a = Math.random();
-        if(scale !== undefined)
-            a *= scale;
-        if(offset !== undefined)
-            a += offset;
-        return a;
+		if(scale !== undefined)
+			a *= scale;
+		if(offset !== undefined)
+			a += offset;
+		return a;
 	}
 
 	function rchoose(gens){
@@ -1129,5 +1129,5 @@
 		return new Uint8Array(N);
 	}
 
-  return jsfx;
+	return jsfx;
 }));

--- a/package.json
+++ b/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "jsfx-audio",
+  "version": "1.0.0",
+  "description": "This is a JavaScript library for sound effect generation and is supported on most current browsers.",
+  "main": "jsfx.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/loov/jsfx.git"
+  },
+  "keywords": [
+    "audio",
+    "sound",
+    "effects",
+    "jsfx"
+  ],
+  "author": "loov",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/loov/jsfx/issues"
+  },
+  "homepage": "https://github.com/loov/jsfx#readme"
+}


### PR DESCRIPTION
Hello! I'm pretty jazzed on jsfx and looking to use it in an app that uses NPM modules to handle dependencies, and so it would be convenient if jsfx could be packaged as an NPM module as well.

In this pull request, I updated jsfx.js to be able to be executed as either an IIFE (as it is currently) or as an NPM module. I based my changes on [this post from NPM](http://blog.npmjs.org/post/112712169830/making-your-jquery-plugin-work-better-with-npm) and this [blog post](http://ifandelse.com/its-not-hard-making-your-library-support-amd-and-commonjs/). The update should not break any compatibility with previous versions of jsfx.

If these changes work for you and you're interested, it'd be extra handy if you wouldn't mind  [publishing jsfx to NPM](https://docs.npmjs.com/getting-started/publishing-npm-packages).

In case it's useful, I also created a [demo app](https://github.com/mtmckenna/jsfx-app-with-node) that is your `index.html` using the Node module version of jsfx.

Please let me know if you have any questions or thoughts!


Thank you!

McKenna

