### PR TITLE
can use webkitAudioContext (for Safari)

### DIFF
--- a/jsfx.js
+++ b/jsfx.js
@@ -17,6 +17,7 @@
 	var EPSILON = 0.000001;
 
 	var jsfx = {};
+	var AudioContext = window.AudioContext || window.webkitAudioContext;
 
 	jsfx.SampleRate = 0 | 0;
 	jsfx.Sec = 0 | 0;


### PR DESCRIPTION
Hello!

For desktop and mobile Safari, it looks like we still need to use `webKitAudioContext` instead of `AudioContext`. I added a line to prefer `AudioContext` but fall back to `webkitAudioContext` if need be.

Does this look all right to you? Thank you!